### PR TITLE
Move audience validation to JWT validator

### DIFF
--- a/authn/claims.go
+++ b/authn/claims.go
@@ -7,10 +7,9 @@ import (
 
 // Claims is the set of information we extract from the JWT payload.
 type Claims struct {
-	Subject  string       `json:"sub,omitempty"`
-	Audience jwt.Audience `json:"aud,omitempty"`
-	Email    string       `json:"email,omitempty"`
-	Groups   []string     `json:"groups,omitempty"`
+	Subject string   `json:"sub,omitempty"`
+	Email   string   `json:"email,omitempty"`
+	Groups  []string `json:"groups,omitempty"`
 }
 
 // claimExtractor is in charge of extracting meaningful info from JWT payload.

--- a/authn/claims_mozilla.go
+++ b/authn/claims_mozilla.go
@@ -8,11 +8,10 @@ import (
 // mozillaClaims is a specific struct to extract emails and groups from
 // the JWT using Mozilla specific attributes.
 type mozillaClaims struct {
-	Subject  string       `json:"sub"`
-	Audience jwt.Audience `json:"aud"`
-	Email    string       `json:"email"`
-	Emails   []string     `json:"https://sso.mozilla.com/claim/emails"`
-	Groups   []string     `json:"https://sso.mozilla.com/claim/groups"`
+	Subject string   `json:"sub"`
+	Email   string   `json:"email"`
+	Emails  []string `json:"https://sso.mozilla.com/claim/emails"`
+	Groups  []string `json:"https://sso.mozilla.com/claim/groups"`
 }
 
 type mozillaClaimExtractor struct{}
@@ -32,10 +31,9 @@ func (*mozillaClaimExtractor) Extract(token *jwt.JSONWebToken, key *jose.JSONWeb
 	}
 
 	claims := Claims{
-		Subject:  mozclaims.Subject,
-		Audience: mozclaims.Audience,
-		Email:    email,
-		Groups:   mozclaims.Groups,
+		Subject: mozclaims.Subject,
+		Email:   email,
+		Groups:  mozclaims.Groups,
 	}
 
 	return &claims, nil

--- a/authn/generic.go
+++ b/authn/generic.go
@@ -64,7 +64,7 @@ func (v *jwtGenericValidator) config() (*openIDConfiguration, error) {
 		v.cache.Set(cacheKey, data)
 	}
 
-	// XXX: since cache stores bytes, we parse it again at every usage :( ?
+	// Since cache stores bytes, we parse it again at every usage :( ?
 	config := &openIDConfiguration{}
 	err = json.Unmarshal(data, config)
 	if err != nil {
@@ -146,10 +146,12 @@ func (v *jwtGenericValidator) ValidateRequest(r *http.Request) (*Claims, error) 
 		return nil, errors.Wrap(err, "failed to read JWT payload")
 	}
 
-	// 5. Validate issuer, claims and expiration.
-	// Will check audience only when request comes in, leave empty for now.
-	audience := []string{}
-	expected := jwt.Expected{Issuer: v.Issuer, Audience: audience}
+	// 5. Validate issuer, audience, claims and expiration.
+	origin := r.Header.Get("Origin")
+	expected := jwt.Expected{
+		Issuer:   v.Issuer,
+		Audience: jwt.Audience{origin},
+	}
 	expected = expected.WithTime(time.Now())
 	err = jwtClaims.Validate(expected)
 	if err != nil {

--- a/authn/generic_test.go
+++ b/authn/generic_test.go
@@ -122,8 +122,14 @@ func TestValidateRequest(t *testing.T) {
 	require.NotNil(t, err)
 	assert.Contains(t, err.Error(), "error in cryptographic primitive")
 
-	// Invalid claims
+	// Invalid audience
 	r.Header.Set("Authorization", "Bearer "+goodJWT)
+	_, err = validator.ValidateRequest(r)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "validation failed, invalid audience claim")
+
+	// Valid claims, expired token.
+	r.Header.Set("Origin", "SLocf7Sa1ibd5GNJMMqO539g7cKvWBOI")
 	_, err = validator.ValidateRequest(r)
 	require.NotNil(t, err)
 	assert.Contains(t, err.Error(), "validation failed, token is expired")

--- a/doorman/middleware.go
+++ b/doorman/middleware.go
@@ -62,14 +62,6 @@ func VerifyJWTMiddleware(doorman Doorman) gin.HandlerFunc {
 			return
 		}
 
-		// Check that origin matches audiences from JWT token .
-		if !claims.Audience.Contains(origin) {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"message": "Invalid audience claim",
-			})
-			return
-		}
-
 		principals := extractPrincipals(claims)
 
 		c.Set(PrincipalsContextKey, principals)

--- a/doorman/middleware_test.go
+++ b/doorman/middleware_test.go
@@ -42,10 +42,9 @@ func TestJWTMiddleware(t *testing.T) {
 
 	// Extract claims is ran on every request.
 	claims := &authn.Claims{
-		Subject:  "ldap|user",
-		Audience: []string{audience},
-		Email:    "user@corp.com",
-		Groups:   []string{"Employee", "Admins"},
+		Subject: "ldap|user",
+		Email:   "user@corp.com",
+		Groups:  []string{"Employee", "Admins"},
 	}
 	v.On("ValidateRequest", mock.Anything).Return(claims, nil)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
@@ -92,8 +91,7 @@ func TestJWTMiddleware(t *testing.T) {
 
 	// Missing attributes in JWT Payload
 	claims = &authn.Claims{
-		Subject:  "ldap|user",
-		Audience: []string{audience},
+		Subject: "ldap|user",
 	}
 	v = &TestValidator{}
 	v.On("ValidateRequest", mock.Anything).Return(claims, nil)
@@ -104,19 +102,4 @@ func TestJWTMiddleware(t *testing.T) {
 	handler(c)
 	principals, _ = c.Get(PrincipalsContextKey)
 	assert.Equal(t, Principals{"userid:ldap|user"}, principals)
-
-	// Audience mismatch origin
-	claims = &authn.Claims{
-		Subject:  "ldap|user",
-		Audience: []string{"http://some.other.api"},
-	}
-	v = &TestValidator{}
-	v.On("ValidateRequest", mock.Anything).Return(claims, nil)
-	doorman.jwtValidators[audience] = v
-	c, _ = gin.CreateTestContext(httptest.NewRecorder())
-	c.Request, _ = http.NewRequest("GET", "/get", nil)
-	c.Request.Header.Set("Origin", audience)
-	handler(c)
-	_, ok = c.Get(PrincipalsContextKey)
-	assert.False(t, ok)
 }


### PR DESCRIPTION
The audience should match the value of the Origin header.

This PR does not change the behaviour but kind of gathers everything related to JWT ID tokens validation in the same place. 